### PR TITLE
add 'Button' class and 'setButtons' method for RichPresence

### DIFF
--- a/src/main/java/com/jagrosh/discordipc/entities/Button.java
+++ b/src/main/java/com/jagrosh/discordipc/entities/Button.java
@@ -1,0 +1,29 @@
+package com.jagrosh.discordipc.entities;
+
+import java.io.Serializable;
+
+public class Button implements Serializable
+{
+    public static final Button DEFAULT = new Button("", "");
+
+    public final String LABEL;
+    public final String url;
+    
+    public Button(final String label, final String url) {
+        if(label == null || url == null) throw new IllegalArgumentException("Button label and url cannot be null!");
+        if(label.isEmpty() || url.isEmpty()) throw new IllegalArgumentException("Button label and url cannot be empty!");
+        if(label.length() > 32) throw new IllegalArgumentException("Button label must be 32 characters or less!");
+        if(url.length() > 512) throw new IllegalArgumentException("Button url must be 512 characters or less!");
+        
+        this.LABEL = label;
+        this.url = url;
+    }
+    
+    public Button(final Button other) {
+        this(other.LABEL, other.url);
+    }
+    
+    public Button copy() {
+        return new Button(this);
+    }
+}

--- a/src/main/java/com/jagrosh/discordipc/entities/RichPresence.java
+++ b/src/main/java/com/jagrosh/discordipc/entities/RichPresence.java
@@ -16,11 +16,11 @@
 
 package com.jagrosh.discordipc.entities;
 
+import java.util.Objects;
+
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonPrimitive;
-
-import java.util.Objects;
 
 /**
  * An encapsulation of all data needed to properly construct a JSON RichPresence payload.
@@ -601,6 +601,30 @@ public class RichPresence {
         public Builder setButtons(JsonArray buttons) {
             this.buttons = buttons;
             return this;
+        }
+
+        /**
+         * Sets the buttons to display on the Rich Presence.
+         * 
+         * @param buttons The buttons to display on the Rich Presence. (Max 2).
+         * 
+         * @return This Builder.
+         */
+        public Builder setButtons(final Button... buttons) {
+            /* If no buttons given then just return the builder. This allow to clear the list */
+            if(buttons == null) return this;
+
+            final JsonArray BUTTONS = new JsonArray();
+            for (Button button : buttons) {
+                final JsonObject BTN_OBJ = new JsonObject();
+                /* Add button to the object */
+                BTN_OBJ.addProperty("label", button.LABEL);
+                BTN_OBJ.addProperty("url", button.url);
+
+                /* Add the object to the list */
+                BUTTONS.add(BTN_OBJ);
+            }
+            return setButtons(BUTTONS);
         }
 
         /**


### PR DESCRIPTION
This PR introduces a fluent, Java-based API for constructing Discord Rich Presence buttons.

Currently, adding buttons requires manual JSON manipulation or direct interaction with the GSON library. This change abstracts those implementation details, allowing developers to define buttons using standard Java objects, improving type safety and code readability. (While maintaining backward compatibility for those who prefer to use JSON-based approach).

**Input Validation**:
- `null` variables.
- Empty strings for labels or URLs.
- Max label and URLs sizes.

```java
presence_builder.setButtons( // varargs
 new Button("Join Me", "https://example.com"),
 new Button("Another Cool Button", "https://example.com")
);
```

I hope this addition proves useful! If you have any questions or feedback regarding the implementation, please don't hesitate to reach out.